### PR TITLE
Getting rid of the rejected attribute

### DIFF
--- a/DOMFuture.idl
+++ b/DOMFuture.idl
@@ -279,7 +279,6 @@ module events {
 
     attribute readonly any         value;
     attribute readonly any         error;
-    attribute readonly boolean     rejected;
     attribute readonly FutureState state;
 
     // Returns a Future whose fulfillment value will be the return value


### PR DESCRIPTION
The `f.rejected` attribute is an alias of `f.state === 'rejected'`. It's unclear why this one would need an alias and not the others.
