### PR TITLE
Add package.json for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "dom-promises",
+  "version": "0.0.1",
+  "description": "DOM Promises Polyfill",
+  "keywords": [
+    "promises",
+    "futures",
+    "dom promises",
+    "dom futures",
+    "polyfill"
+  ],
+  "bugs": "https://github.com/slightlyoff/Promises/issues",
+  "licenses": [
+    {
+      "type": "Apache License, Version 2.0",
+      "url": "https://github.com/slightlyoff/Promises/blob/master/polyfill/LICENSE"
+    }
+  ],
+  "author": {
+    "name": "Alex Russell",
+    "email": "slightlyoff@chromium.org",
+    "url": "http://infrequently.org/"
+  },
+  "main": "./polyfill/bin/Promise.min.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/slightlyoff/Promises.git"
+  },
+  "dependencies": {}
+}


### PR DESCRIPTION
For #50. You may need to alter the code a bit (e.g. add `module.exports = Promise;`), but this will at least get you started.

Most of the `package.json` file is self-explanatory, but the magic happens by using `main` and setting it to the minified polyfill file. This way, every time the package is `require`d, it will require that file specifically, without having to change the structure of the repo at all (and making it easy to change the structure in the future without breaking anything for users).

Oh, and it would be a good idea to run [`npm publish`](https://npmjs.org/doc/publish.html) after so people can install with `npm install dom-promises`.
